### PR TITLE
Refactor/#5 redis 캐시 도입

### DIFF
--- a/celery_consumer/.gitignore
+++ b/celery_consumer/.gitignore
@@ -5,6 +5,5 @@ voice_model_new/*.json
 voice_model_new/*.npy
 wav/*.wav
 voicepocket-bucketKey.json
-synthesizer.pickle
 .DS_Store
 .erlang.cookie

--- a/celery_consumer/requirements.txt
+++ b/celery_consumer/requirements.txt
@@ -2,6 +2,7 @@ amqp==5.1.1
 anyascii==0.3.1
 asgiref==3.6.0
 astroid==2.7.3
+async-timeout==4.0.2
 audioread==3.0.0
 Babel==2.12.1
 billiard==3.6.4.0
@@ -96,6 +97,7 @@ pytz==2022.7.1
 pytz-deprecation-shim==0.1.0.post0
 PyYAML==6.0
 rabbitmq==0.2.0
+redis==4.5.4
 regex==2022.10.31
 requests==2.28.2
 resampy==0.4.2

--- a/celery_consumer/text_process.py
+++ b/celery_consumer/text_process.py
@@ -3,7 +3,6 @@ from unicodedata import normalize
 
 import g2pk
 
-#from g2pk import g2pk, english, utils, numerals
 
 def normalize_text(text, symbols):
     text = text.strip()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,22 @@ services:
     volumes:
       - ./celery_consumer:/voice_pocket
 
+  redis:
+    image: redis:latest
+    container_name: voicepocket_redis
+    ports:
+      - 6379:6379
+    # volumes:
+    #   - ./redis/data:/data
+    #   - ./redis/conf/redis.conf:/usr/local/conf/redis.conf
+    labels:
+      - "name=voicepocket_redis"
+      - "mode=standalone"
+    networks:
+      - voicePocket
+    # restart: always
+    command: redis-server # /usr/local/conf/redis.conf
+
 networks:
   voicePocket:
     driver: bridge


### PR DESCRIPTION
기존의 synthesizer.pickle 파일로 object를 저장 및 dictionary에서 관리하던 것을 redis의 캐시메모리에 저장하는 방식으로 바꿨습니다.

redis에 key로 email, value로 synthesizer object를 pickle로 serialize한 대상을 저장합니다.

필요한 라이브러리와 docker-compose 세팅을 마쳤습니다.