### PR TITLE
fix: redis connectionError

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,16 +72,16 @@ services:
     container_name: voicepocket_redis
     ports:
       - 6379:6379
-    # volumes:
-    #   - ./redis/data:/data
-    #   - ./redis/conf/redis.conf:/usr/local/conf/redis.conf
+    volumes:
+      # - ./redis/data:/data
+      - ./redis/conf/redis.conf:/usr/local/conf/redis.conf
     labels:
       - "name=voicepocket_redis"
       - "mode=standalone"
     networks:
       - voicePocket
     # restart: always
-    command: redis-server # /usr/local/conf/redis.conf
+    command: redis-server /usr/local/conf/redis.conf
 
 networks:
   voicePocket:

--- a/redis/conf/redis.conf
+++ b/redis/conf/redis.conf
@@ -1,0 +1,1 @@
+proto-max-bulk-len 1073741824


### PR DESCRIPTION
별도의 redis conf 파일을 만들어 한 번에 처리될 수 있는 data 크기의 제한을 500MB에서 1GB로 늘렸습니다.
추후 음성 학습 데이터의 양이 결정되면 적절한 synthesizer의 용량을 결정하고, 그에 맞는 redis 캐시 서버의 설정을 변경할 예정입니다.