### PR TITLE
Refactor/#15 기존 Polling 방식의 개선

### DIFF
--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/message/controller/MessageController.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/message/controller/MessageController.java
@@ -2,10 +2,8 @@ package com.vp.voicepocket.domain.message.controller;
 
 import com.vp.voicepocket.domain.message.dto.TaskIdResponseDto;
 import com.vp.voicepocket.domain.message.dto.TaskInfoResponseDto;
-import com.vp.voicepocket.domain.message.exception.CTaskNotFinishedException;
-import com.vp.voicepocket.domain.message.exception.CTaskNotFoundException;
-import com.vp.voicepocket.domain.message.model.Message;
-import com.vp.voicepocket.domain.message.service.MessageService;
+import com.vp.voicepocket.domain.message.model.InputMessage;
+import com.vp.voicepocket.domain.message.service.InputMessageService;
 import com.vp.voicepocket.global.common.response.model.SingleResult;
 import com.vp.voicepocket.global.common.response.service.ResponseService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,7 +12,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.json.JSONObject;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -24,7 +21,7 @@ import javax.validation.Valid;
 @Tag(name = "Message")
 @RequestMapping("/api")
 public class MessageController {
-    private final MessageService messageService;
+    private final InputMessageService inputMessageService;
     private final ResponseService responseService;
 
     @Parameter(
@@ -35,9 +32,9 @@ public class MessageController {
             in = ParameterIn.HEADER)
     @Operation(summary = "TTS 요청", description = "Text To Speech 서비스를 요청합니다.")
     @PostMapping("/tts/send")
-    public SingleResult<Message> send(@Valid @RequestBody Message message) {
-        messageService.sendMessage(message);
-        return responseService.getSingleResult(message);
+    public SingleResult<InputMessage> send(@Valid @RequestBody InputMessage inputMessage) {
+        inputMessageService.sendMessage(inputMessage);
+        return responseService.getSingleResult(inputMessage);
     }
 
     @Parameter(
@@ -49,7 +46,7 @@ public class MessageController {
     @Operation(summary = "TTS Task id 체크", description = "uuid로 TTS task id를 얻어옵니다.")
     @GetMapping("/tts/status/uuid/{uuid}")
     public SingleResult<TaskIdResponseDto> getTaskId(@PathVariable String uuid) {
-        return responseService.getSingleResult(messageService.getTaskId(uuid));
+        return responseService.getSingleResult(inputMessageService.getTaskId(uuid));
     }
 
     @Parameter(
@@ -61,6 +58,6 @@ public class MessageController {
     @Operation(summary = "TTS Task 체크", description = "task id로 TTS 작업의 진행상태를 봅니다.")
     @GetMapping("/tts/status/taskId/{taskId}")
     public SingleResult<TaskInfoResponseDto> getTaskStatus(@PathVariable String taskId) {
-        return responseService.getSingleResult(messageService.getTaskStatus(taskId));
+        return responseService.getSingleResult(inputMessageService.getTaskStatus(taskId));
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/message/model/InputMessage.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/message/model/InputMessage.java
@@ -9,8 +9,8 @@ import javax.validation.constraints.NotNull;
 
 @Getter @Setter
 @AllArgsConstructor
-@Schema(title = "Message 모델", description = "TTS 요청을 받을 Message 모델")
-public class Message {
+@Schema(title = "Input Message 모델", description = "TTS 요청을 받을 Message 모델")
+public class InputMessage {
     @NotNull
     @Schema(title = "Message type", description = "메시지 요청에 따른 타입", example = "ETL")
     private String type;

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/message/model/OutputMessage.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/message/model/OutputMessage.java
@@ -1,0 +1,20 @@
+package com.vp.voicepocket.domain.message.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(title = "Output Message 모델", description = "TTS 요청의 수행 결과를 받을 Message 모델")
+public class OutputMessage {
+    @NotNull
+    @Schema(title = "wav file url", description = "생성된 wav 파일의 url")
+    private String url;
+}

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/message/service/InputMessageService.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/message/service/InputMessageService.java
@@ -4,8 +4,7 @@ import com.vp.voicepocket.domain.message.dto.TaskIdResponseDto;
 import com.vp.voicepocket.domain.message.dto.TaskInfoResponseDto;
 import com.vp.voicepocket.domain.message.exception.CTaskNotFinishedException;
 import com.vp.voicepocket.domain.message.exception.CTaskNotFoundException;
-import com.vp.voicepocket.domain.message.model.Message;
-import lombok.Builder;
+import com.vp.voicepocket.domain.message.model.InputMessage;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -16,13 +15,13 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class MessageService {
-    private static final Logger log = LoggerFactory.getLogger(MessageService.class);
+public class InputMessageService {
+    private static final Logger log = LoggerFactory.getLogger(InputMessageService.class);
     private final RabbitTemplate rabbitTemplate;    // RabbitTemplate을 통해 Exchange에 메세지를 보내도록 설정
     private final StringRedisTemplate stringRedisTemplate;
 
-    public void sendMessage(Message message) {
-        rabbitTemplate.convertAndSend("default", "input.key", message);
+    public void sendMessage(InputMessage inputMessage) {
+        rabbitTemplate.convertAndSend("input.exchange", "input.key", inputMessage);
     }
 
     public TaskIdResponseDto getTaskId(String uuid) {

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/message/service/OutputMessageService.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/message/service/OutputMessageService.java
@@ -1,0 +1,20 @@
+package com.vp.voicepocket.domain.message.service;
+
+import com.vp.voicepocket.domain.message.model.OutputMessage;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OutputMessageService {
+    private static final Logger log = LoggerFactory.getLogger(OutputMessageService.class);
+
+    @RabbitListener(queues = "output.queue")
+    public void consume(OutputMessage outputMessage) {  // TODO: push message to FCM
+        log.info(outputMessage.getUrl());
+        System.out.println(outputMessage.getUrl());
+    }
+}

--- a/voicepocket/src/main/java/com/vp/voicepocket/global/config/RabbitConfig.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/global/config/RabbitConfig.java
@@ -1,5 +1,10 @@
 package com.vp.voicepocket.global.config;
 
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -28,10 +33,33 @@ public class RabbitConfig {
     private int port;
 
     @Bean
+    Queue queue() {
+        return new Queue("output.queue", true);
+    }
+
+    @Bean
+    DirectExchange directExchange() {
+        return new DirectExchange("output.exchange");
+    }
+
+    @Bean
+    Binding binding(DirectExchange directExchange, Queue queue) {
+        return BindingBuilder.bind(queue).to(directExchange).with("output.key");
+    }
+
+    @Bean
     RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
         rabbitTemplate.setMessageConverter(messageConverter);
         return rabbitTemplate;
+    }
+
+    @Bean
+    SimpleRabbitListenerContainerFactory simpleRabbitListenerContainerFactory(ConnectionFactory connectionFactory) {
+        final SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(messageConverter());
+        return factory;
     }
 
     @Bean


### PR DESCRIPTION
celery task의 종료 확인 방법을 기존의 polling 방식에서 수정했습니다.
celery worker가 tts task를 다 수행한 뒤, 완료 message를 rabbitMQ로 publish하여 spring boot 백엔드가 해당 message를 consume하도록 구성했습니다.

FCM과 연동하여 푸시 메시지를 보내는 것은 추후에 기능추가로 구현하겠습니다.