### PR TITLE
fix: 두 칼럼을 묶은 unique key 제약 조건 추가

### DIFF
--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/friend/entity/Friend.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/friend/entity/Friend.java
@@ -13,7 +13,11 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name="Friends")
+@Table(name="Friends", uniqueConstraints = {
+    @UniqueConstraint(
+        columnNames = {"request_from", "request_to"}
+    )
+})
 @Entity
 public class Friend extends BaseEntity {
     @Id


### PR DESCRIPTION
팔로우 신청 테이블에 유니크키 제약 조건을 걸어줌으로써 
db 단에서 중복 요청에 대한 동시적 요청으로 인한 중복 insert 상황을 방지하도록 구현했습니다.
(request_from 칼럼과 request_to 칼럼을 묶어 하나의 unique 제약 조건을 추가함)
