### PR TITLE
Refactor/#40 synthesizer 관리 방식 개선

### DIFF
--- a/celery_consumer/celery_consume.py
+++ b/celery_consumer/celery_consume.py
@@ -36,9 +36,10 @@ def text_to_speech(uuid, email, text, sender_email):
     except Exception as e:
         message = {"requestFrom": sender_email, "requestTo":email,"result": e, "url":url_path, "uuid":uuid}
     
-    publish_message(message)
-        
-    return url_path
+    finally:
+        publish_message(message)
+
+        return url_path
 
 
 # publish message when TTS done

--- a/celery_consumer/tts_process.py
+++ b/celery_consumer/tts_process.py
@@ -1,37 +1,30 @@
-import os, sys, tarfile, pickle
+import os, pickle
 
 from TTS.utils.synthesizer import Synthesizer
 from text_process import normalize_text
-from bucket_process import down_model_from_bucket, upload_wav_to_bucket
+from bucket_process import download_model_from_bucket, upload_wav_to_bucket, check_model_exist, upload_model_to_bucket
 
 
 def is_set(email):
-    return os.path.exists(f'./synth/{email}_synth.p')
+    return check_model_exist(email)
 
 def add_synth(email):
-    # TODO: best 모델 구성이 결정되면 그에 맞춰 코드를 수정할 것!
-    # voice_model_path = f"./api_server/voice_model/{email}_best_model.pth.tar"
-    
-    # if not os.path.isfile(voice_model_path):
-    #     down_model_from_bucket(email)
-        
-    #     best_model_tar = tarfile.open(voice_model_path)
-    #     best_model_tar.extractall(f"./api_server/voice_model")
-    
+    # TODO: download original_wav file from bucket
+
+    # TODO: setting synthesizer from original_wav
     synthesizer = Synthesizer(
         tts_checkpoint = f"./voice_model_new/{email}_model.pth",
         tts_config_path = f"./voice_model_new/{email}_config.json"
     )
 
-    with open(f'./synth/{email}_synth.p', 'wb') as p:
-        pickle.dump(synthesizer, p)
+    # upload synthesizer to bucket
+    upload_model_to_bucket(email, pickle.dumps(synthesizer))
 
     
 def make_tts(email, uuid, text):
     wav_path = f'./wav/{uuid}.wav'
-    
-    with open(f'./synth/{email}_synth.p', 'rb') as p:
-        syn = pickle.load(p)
+    model = download_model_from_bucket(email)
+    syn = pickle.loads(model)
 
     symbol = syn.tts_config.characters.characters
     text = normalize_text(text, symbol)


### PR DESCRIPTION
기존 데모 버전은 synthesizer object를 binary화 하여 파일 형태로 관리했지만, 
gcs bucket 공식 문서를 살펴보던 중 binary 데이터 자체를 bucket에 저장할 수 있다는 것을 발견하여
파일 형태로 bucket에서 주고 받았던 것을 binary 데이터 자체로 주고 받도록 수정했습니다.