### PR TITLE
Refact/#48 Security Refactoring

### DIFF
--- a/voicepocket/src/main/java/com/vp/voicepocket/VoicepocketApplication.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/VoicepocketApplication.java
@@ -2,19 +2,11 @@ package com.vp.voicepocket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
 public class VoicepocketApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(VoicepocketApplication.class, args);
-	}
-
-	@Bean
-	public PasswordEncoder passwordEncoder() {
-		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
 	}
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/friend/controller/FriendController.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/friend/controller/FriendController.java
@@ -10,19 +10,18 @@ import com.vp.voicepocket.global.common.response.model.ListResult;
 import com.vp.voicepocket.global.common.response.model.SingleResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,79 +34,47 @@ public class FriendController {
 
     private final FriendService friendService;
 
-    @Parameter(
-        name = "X-AUTH-TOKEN",
-        description = "로그인 성공 후 AccessToken",
-        required = true,
-        schema = @Schema(type = "string"),
-        in = ParameterIn.HEADER)
     @Operation(summary = "친구 요청", description = "친구 요청을 합니다.")
     @PostMapping("/friend")
     public SingleResult<FriendResponseDto> friendRequest(
-        @RequestHeader("X-AUTH-TOKEN") String accessToken,
-        @Parameter(description = "친구 요청 DTO", required = true)
-        @RequestBody @Valid FriendRequestDto friendRequestDto) {
-        FriendResponseDto friendResponseDto = friendService.requestFriend(
-            friendRequestDto.getEmail(), accessToken);
+        @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+        @Parameter(description = "친구 요청 DTO", required = true) @RequestBody @Valid FriendRequestDto friendRequestDto) {
+        FriendResponseDto friendResponseDto = friendService.requestFriend(userDetails, friendRequestDto.getEmail());
         return ResponseFactory.createSingleResult(friendResponseDto);
     }
 
-    @Parameter(
-        name = "X-AUTH-TOKEN",
-        description = "로그인 성공 후 AccessToken",
-        required = true,
-        schema = @Schema(type = "string"),
-        in = ParameterIn.HEADER)
     @Operation(summary = "친구 요청 리스트 확인", description = "나에게 온 친구 요청을 확인합니다.")
     @GetMapping("/friend/requests")
     public ListResult<FriendResponseDto> checkRequest(
-        @RequestHeader("X-AUTH-TOKEN") String accessToken) {
-        return ResponseFactory.createListResult(friendService.checkRequest(accessToken));
+        @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseFactory.createListResult(friendService.checkRequest(userDetails));
     }
 
-    @Parameter(
-        name = "X-AUTH-TOKEN",
-        description = "로그인 성공 후 AccessToken",
-        required = true,
-        schema = @Schema(type = "string"),
-        in = ParameterIn.HEADER)
     @Operation(summary = "친구 리스트 조회", description = "내 친구 리스트를 조회합니다.")
     @GetMapping("/friend")
     public ListResult<FriendResponseDto> checkResponse(
-        @RequestHeader("X-AUTH-TOKEN") String accessToken) {
-        return ResponseFactory.createListResult(friendService.checkResponse(accessToken));
+        @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseFactory.createListResult(friendService.checkResponse(userDetails));
     }
 
-    @Parameter(
-        name = "X-AUTH-TOKEN",
-        description = "로그인 성공 후 AccessToken",
-        required = true,
-        schema = @Schema(type = "string"),
-        in = ParameterIn.HEADER)
     @Operation(summary = "친구 요청 취소", description = "친구 요청을 취소합니다.")
     @DeleteMapping("/friend")
     public CommonResult deleteRequest(
-        @RequestHeader("X-AUTH-TOKEN") String accessToken,
+        @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
         @Parameter(description = "친구 요청 DTO", required = true)
         @RequestBody FriendRequestDto friendRequestDto) {
-        friendService.delete(friendRequestDto, accessToken);
+        friendService.delete(userDetails, friendRequestDto);
         return ResponseFactory.createSuccessResult();
     }
 
-    @Parameter(
-        name = "X-AUTH-TOKEN",
-        description = "로그인 성공 후 AccessToken",
-        required = true,
-        schema = @Schema(type = "string"),
-        in = ParameterIn.HEADER)
     @Operation(summary = "친구 요청 관리", description = "친구 요청을 수락하거나 거절합니다.")
     @PutMapping("/friend/request/{Status}")
     public CommonResult handlingRequest(
-        @RequestHeader("X-AUTH-TOKEN") String accessToken,
+        @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
         @Parameter(description = "친구 요청 DTO", required = true)
         @RequestBody FriendRequestDto friendRequestDto,
         @PathVariable(name = "Status") Status status) {
-        friendService.update(friendRequestDto.getEmail(), accessToken, status);
+        friendService.update(userDetails, friendRequestDto.getEmail(), status);
         return ResponseFactory.createSuccessResult();
     }
 

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/message/controller/MessageController.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/message/controller/MessageController.java
@@ -2,38 +2,33 @@ package com.vp.voicepocket.domain.message.controller;
 
 import com.vp.voicepocket.domain.message.dto.TTSRequestDto;
 import com.vp.voicepocket.domain.message.service.InputMessageService;
+import com.vp.voicepocket.global.common.response.ResponseFactory;
 import com.vp.voicepocket.global.common.response.model.CommonResult;
-import com.vp.voicepocket.global.common.response.service.ResponseService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
 import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Message")
 @RequestMapping("/api")
 public class MessageController {
-    private final InputMessageService inputMessageService;
-    private final ResponseService responseService;
 
-    @Parameter(
-            name = "X-AUTH-TOKEN",
-            description = "로그인 성공 후 AccessToken",
-            required = true,
-            schema = @Schema(type = "string"),
-            in = ParameterIn.HEADER)
+    private final InputMessageService inputMessageService;
+
     @Operation(summary = "TTS 요청", description = "Text To Speech 서비스를 요청합니다.")
     @PostMapping("/tts/send")
     public CommonResult send(
-            @RequestHeader("X-AUTH-TOKEN") String accessToken,
-            @Valid @RequestBody TTSRequestDto ttsRequestDto) {
-        inputMessageService.sendMessage(accessToken, ttsRequestDto);
-        return responseService.getSuccessResult();
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody @Valid TTSRequestDto ttsRequestDto) {
+        inputMessageService.sendMessage(userDetails, ttsRequestDto);
+        return ResponseFactory.createSuccessResult();
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/message/dto/TTSRequestDto.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/message/dto/TTSRequestDto.java
@@ -1,28 +1,29 @@
 package com.vp.voicepocket.domain.message.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import javax.validation.constraints.NotNull;
 
 @Getter
 @AllArgsConstructor
 @Schema(title = "Input Message 모델", description = "TTS 요청을 받을 Message 모델")
 public class TTSRequestDto {
-    @NotNull
+
     @Schema(title = "Message type", description = "메시지 요청에 따른 타입", example = "ETL")
+    @NotBlank
     private String type;
 
-    @NotNull
     @Schema(title = "Request UUID", description = "TTS 요청에 대한 UUID", example = "550k8400-e29b-41d4-a716-446655440001")
+    @NotBlank
     private String uuid;
 
-    @NotNull
     @Schema(title = "Requested User Email", description = "음성 합성 요청을 받은 사용자의 이메일", example = "ssh@gmail.com")
+    @Email
     private String requestTo;
 
-    @NotNull
     @Schema(title = "Text", description = "합성을 원하는 문장", example = "테스트 문장입니다.")
+    @NotBlank
     private String text;
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/message/service/InputMessageService.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/message/service/InputMessageService.java
@@ -2,32 +2,29 @@ package com.vp.voicepocket.domain.message.service;
 
 import com.vp.voicepocket.domain.message.dto.TTSRequestDto;
 import com.vp.voicepocket.domain.message.model.InputMessage;
-import com.vp.voicepocket.domain.token.config.JwtProvider;
-import com.vp.voicepocket.domain.token.exception.CAccessTokenException;
 import com.vp.voicepocket.domain.user.entity.User;
 import com.vp.voicepocket.domain.user.exception.CUserNotFoundException;
 import com.vp.voicepocket.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InputMessageService {
-    private static final Logger log = LoggerFactory.getLogger(InputMessageService.class);
+
     private final RabbitTemplate rabbitTemplate;    // RabbitTemplate을 통해 Exchange에 메세지를 보내도록 설정
     private final UserRepository userRepository;
-    private final JwtProvider jwtProvider;
 
     @Transactional
-    public void sendMessage(String jwtToken, TTSRequestDto ttsRequestDto) {
-        Authentication authentication = getAuthByAccessToken(jwtToken);
+    public void sendMessage(UserDetails userDetails, TTSRequestDto ttsRequestDto) {
+        Long userId = Long.parseLong(userDetails.getUsername());
 
-        User user = userRepository.findById(Long.parseLong(authentication.getName()))
+        User user = userRepository.findById(userId)
                 .orElseThrow(CUserNotFoundException::new);
 
         InputMessage inputMessage = InputMessage.builder()
@@ -37,17 +34,8 @@ public class InputMessageService {
                 .requestTo(ttsRequestDto.getRequestTo())
                 .text(ttsRequestDto.getText())
                 .build();
-
+        log.debug("inputMessage: {}", inputMessage);
         rabbitTemplate.convertAndSend("input.exchange", "input.key", inputMessage);
     }
 
-    private Authentication getAuthByAccessToken(String accessToken) {
-        // 만료된 access token 인지 확인
-        if (!jwtProvider.validationToken(accessToken)) {
-            throw new CAccessTokenException();
-        }
-
-        // AccessToken 에서 Username (pk) 가져오기
-        return jwtProvider.getAuthentication(accessToken);
-    }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/config/JwtAuthenticationFilter.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/config/JwtAuthenticationFilter.java
@@ -2,6 +2,9 @@ package com.vp.voicepocket.domain.token.config;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
+import com.vp.voicepocket.domain.token.exception.CAuthenticationEntryPointException;
+import com.vp.voicepocket.domain.user.entity.enums.UserRole;
+import io.jsonwebtoken.Claims;
 import java.io.IOException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -9,8 +12,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -20,13 +26,16 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final UserDetailsService userDetailsService;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-        FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
+        @NonNull FilterChain filterChain) throws ServletException, IOException {
         try {
             String accessToken = validateAccessToken(request.getHeader(AUTHORIZATION));
-            Authentication authentication = jwtProvider.validateAndGetAuthentication(accessToken);
+            var claims = jwtProvider.parseAccessToken(accessToken);
+            validateClaims(claims);
+            var authentication = generateAuthenticationToken(claims.getSubject());
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (Exception e) {
             request.setAttribute("exception", e);
@@ -40,6 +49,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         // "Bearer " 제거
         return accessToken.substring(7);
+    }
+
+    private void validateClaims(Claims claims) {
+        var role = claims.get("role", String.class);
+        var userId = claims.getSubject();
+        if (role == null || !UserRole.isUserRole(role) || userId == null) {
+            throw new CAuthenticationEntryPointException();
+        }
+    }
+
+    private Authentication generateAuthenticationToken(String userId) {
+        var userDetails = userDetailsService.loadUserByUsername(userId);
+        return new UsernamePasswordAuthenticationToken(userDetails, "",
+            userDetails.getAuthorities());
     }
 
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/config/JwtProvider.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/config/JwtProvider.java
@@ -14,7 +14,6 @@ import io.jsonwebtoken.impl.TextCodec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -118,11 +117,6 @@ public class JwtProvider {
         UserDetails userDetails = userDetailsService.loadUserByUsername(claims.getSubject());
         return new UsernamePasswordAuthenticationToken(userDetails, "",
             userDetails.getAuthorities());
-    }
-
-    // HTTP Request 의 Header 에서 Token Parsing -> "X-AUTH-TOKEN: jwt"
-    public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("X-AUTH-TOKEN");
     }
 
     // jwt 의 유효성 및 만료 일자 확인

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/config/JwtProvider.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/config/JwtProvider.java
@@ -1,25 +1,18 @@
 package com.vp.voicepocket.domain.token.config;
 
 import com.vp.voicepocket.domain.token.dto.TokenDto;
-import com.vp.voicepocket.domain.token.exception.CAuthenticationEntryPointException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.impl.TextCodec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -32,15 +25,11 @@ public class JwtProvider {
 
     private final String secretKey;
     private final String issuer;
-    private final UserDetailsService userDetailsService;
-
     private final JwtParser jwtParser;
 
-    public JwtProvider(@Value("${spring.jwt.secret}") String secretKey,
-        @Value("${spring.jwt.issuer}") String issuer, UserDetailsService userDetailsService) {
+    public JwtProvider(@Value("${spring.jwt.secret}") String secretKey, @Value("${spring.jwt.issuer}") String issuer) {
         this.secretKey = TextCodec.BASE64URL.encode(secretKey.getBytes(StandardCharsets.UTF_8));
         this.issuer = issuer;
-        this.userDetailsService = userDetailsService;
         this.jwtParser = Jwts.parser().setSigningKey(secretKey);
     }
 
@@ -83,50 +72,6 @@ public class JwtProvider {
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }
-    }
-
-    // Jwt 토큰 복호화해서 가져오기
-    private Claims parseClaims(String token) {
-        try {
-            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
-        } catch (ExpiredJwtException e) {
-            return e.getClaims();
-        }
-    }
-
-    // Jwt 로 인증정보를 조회
-    @Deprecated(forRemoval = true)
-    public Authentication getAuthentication(String token) {
-
-        // Jwt 에서 claims 추출
-        Claims claims = parseClaims(token);
-
-        // 권한 정보가 없음
-        if (claims.get(ROLE) == null) {
-            throw new CAuthenticationEntryPointException();
-        }
-
-        UserDetails userDetails = userDetailsService.loadUserByUsername(claims.getSubject());
-        return new UsernamePasswordAuthenticationToken(userDetails, "",
-            userDetails.getAuthorities());
-    }
-
-    // jwt 의 유효성 및 만료 일자 확인
-    @Deprecated(forRemoval = true)
-    public boolean validationToken(String token) {
-        try {
-            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
-            return true;
-        } catch (SecurityException | MalformedJwtException e) {
-            log.error("잘못된 Jwt 서명입니다.");
-        } catch (ExpiredJwtException e) {
-            log.error("만료된 토큰입니다.");
-        } catch (UnsupportedJwtException e) {
-            log.error("지원하지 않는 토큰입니다.");
-        } catch (IllegalArgumentException e) {
-            log.error("잘못된 토큰입니다.");
-        }
-        return false;
     }
 
     private Date calculateAccessTokenExpiryDate(Date now) {

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/dto/TokenDto.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/dto/TokenDto.java
@@ -2,27 +2,30 @@ package com.vp.voicepocket.domain.token.dto;
 
 import com.vp.voicepocket.domain.token.entity.RefreshToken;
 import com.vp.voicepocket.domain.user.entity.User;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class TokenDto {
-    private String grantType;
-    private String accessToken;
-    private String refreshToken;
-    private Long accessTokenExpireDate;
 
-    public RefreshToken toEntity(User user){
+    private final String grantType;
+    private final String accessToken;
+    private final String refreshToken;
+    private final Long refreshTokenExpiryDate;
+
+    @Builder
+    public TokenDto(String accessToken, String refreshToken, Long refreshTokenExpiryDate) {
+        this.grantType = "Bearer";
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpiryDate = refreshTokenExpiryDate;
+    }
+
+    // TODO: ??
+    public RefreshToken toEntity(User user) {
         return RefreshToken.builder()
-                .key(user.getId())
-                .token(refreshToken)
-                .build();
+            .key(user.getId())
+            .token(refreshToken)
+            .build();
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/dto/TokenDto.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/dto/TokenDto.java
@@ -24,8 +24,9 @@ public class TokenDto {
     // TODO: ??
     public RefreshToken toEntity(User user) {
         return RefreshToken.builder()
-            .key(user.getId())
-            .token(refreshToken)
+            .id(user.getId())
+            .refreshToken(refreshToken)
+            .expiryDate(refreshTokenExpiryDate)
             .build();
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/dto/TokenDto.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/dto/TokenDto.java
@@ -1,7 +1,5 @@
 package com.vp.voicepocket.domain.token.dto;
 
-import com.vp.voicepocket.domain.token.entity.RefreshToken;
-import com.vp.voicepocket.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -21,12 +19,4 @@ public class TokenDto {
         this.refreshTokenExpiryDate = refreshTokenExpiryDate;
     }
 
-    // TODO: ??
-    public RefreshToken toEntity(User user) {
-        return RefreshToken.builder()
-            .id(user.getId())
-            .refreshToken(refreshToken)
-            .expiryDate(refreshTokenExpiryDate)
-            .build();
-    }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/dto/TokenRequestDto.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/dto/TokenRequestDto.java
@@ -1,20 +1,16 @@
 package com.vp.voicepocket.domain.token.dto;
 
-import lombok.Builder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class TokenRequestDto {
-    String accessToken;
+
+    @Schema(title = "refreshToken", description = "리프레시 토큰", example = "sampleToken")
+    @NotBlank
     String refreshToken;
 
-    @Builder
-    public TokenRequestDto(String accessToken, String refreshToken) {
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-    }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/entity/RefreshToken.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/entity/RefreshToken.java
@@ -1,6 +1,8 @@
 package com.vp.voicepocket.domain.token.entity;
 
 
+import com.vp.voicepocket.domain.token.exception.CRefreshTokenException;
+import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -36,6 +38,12 @@ public class RefreshToken {  // 추후 expire 시간과 비교하여 만료시�
     public void updateToken(String refreshToken, Long expiryDate) {
         this.value = validateToken(refreshToken);
         this.expiryDate = validateExpiryDate(expiryDate);
+    }
+
+    public void validateRefreshToken(String refreshToken) {
+        if (!this.value.equals(refreshToken) || this.expiryDate < new Date().getTime()) {
+            throw new CRefreshTokenException();
+        }
     }
 
     private Long validateId(Long id) {

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/entity/RefreshToken.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/entity/RefreshToken.java
@@ -1,36 +1,61 @@
 package com.vp.voicepocket.domain.token.entity;
 
 
-import com.vp.voicepocket.global.common.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
-
 @Entity
-@Table(name = "Refresh_token")
 @Getter
-@NoArgsConstructor
-public class RefreshToken extends BaseEntity {  // 추후 expire 시간과 비교하여 만료시켜주기 위해 BaseEntity를 상속하여 time 정보를 받아옴
+@Table(name = "refresh_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {  // 추후 expire 시간과 비교하여 만료시켜주기 위해 BaseEntity를 상속하여 time 정보를 받아옴
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, unique = true, updatable = false, insertable = false)
     private Long id;
 
-    @Column(nullable = false, name = "token_key") // key가 예약어일 가능성이 있기에 column명을 바꿔줌
-    private Long key;   // 객체를 가져오기 위한 용도. 토큰의 claims의 값은 공개값이므로 유저를 특정할 수 없는 userPk값을 key값으로 해줌
+    @Column(nullable = false)
+    private String value;
 
     @Column(nullable = false)
-    private String token;
-
-    public void updateToken(String token) {
-        this.token = token;
-    }
+    private Long expiryDate;
 
     @Builder
-    public RefreshToken(Long key, String token) {
-        this.key = key;
-        this.token = token;
+    private RefreshToken(Long id, String refreshToken, Long expiryDate) {
+        this.id = validateId(id);
+        this.value = validateToken(refreshToken);
+        this.expiryDate = validateExpiryDate(expiryDate);
+    }
+
+    public void updateToken(String refreshToken, Long expiryDate) {
+        this.value = validateToken(refreshToken);
+        this.expiryDate = validateExpiryDate(expiryDate);
+    }
+
+    private Long validateId(Long id) {
+        if (id == null || id <= 0) {
+            throw new IllegalArgumentException("RefreshToken id is null");
+        }
+        return id;
+    }
+
+    private String validateToken(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new IllegalArgumentException("RefreshToken value is null");
+        }
+        return refreshToken;
+    }
+
+    private Long validateExpiryDate(Long expiryDate) {
+        if (expiryDate == null || expiryDate <= 0) {
+            throw new IllegalArgumentException("RefreshToken expiryDate is null");
+        }
+        return expiryDate;
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/repository/RefreshTokenRepository.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/repository/RefreshTokenRepository.java
@@ -2,14 +2,11 @@ package com.vp.voicepocket.domain.token.repository;
 
 
 import com.vp.voicepocket.domain.token.entity.RefreshToken;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
-
-    Optional<RefreshToken> findByKey(Long key);
-
-    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByValue(String token);
 }
 

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/token/repository/RefreshTokenRepository.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/token/repository/RefreshTokenRepository.java
@@ -2,11 +2,9 @@ package com.vp.voicepocket.domain.token.repository;
 
 
 import com.vp.voicepocket.domain.token.entity.RefreshToken;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
-    Optional<RefreshToken> findByValue(String token);
 }
 

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/controller/SignController.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/controller/SignController.java
@@ -6,19 +6,17 @@ import com.vp.voicepocket.domain.token.dto.TokenRequestDto;
 import com.vp.voicepocket.domain.user.dto.request.UserLoginRequestDto;
 import com.vp.voicepocket.domain.user.dto.request.UserSignupRequestDto;
 import com.vp.voicepocket.domain.user.service.SignService;
+import com.vp.voicepocket.global.common.response.ResponseFactory;
 import com.vp.voicepocket.global.common.response.model.SingleResult;
 import com.vp.voicepocket.global.common.response.service.ResponseService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -41,21 +39,13 @@ public class SignController {
         return responseService.getSingleResult(signupId);
     }
 
-    @Parameter(
-            name = "FCM-TOKEN",
-            description = "FCM Token",
-            required = true,
-            schema = @Schema(type = "string"),
-            in = ParameterIn.HEADER)
     @Operation(summary = "로그인", description = "이메일로 로그인을 합니다.")
     @PostMapping("/login")
     public SingleResult<TokenDto> login(
-            @RequestHeader("FCM-TOKEN") String fcmToken,
             @Parameter(description = "로그인 요청 DTO", required = true)
             @RequestBody @Valid UserLoginRequestDto userLoginRequestDto) {
-
-        TokenDto tokenDto = signService.login(fcmToken, userLoginRequestDto);
-        return responseService.getSingleResult(tokenDto);
+        TokenDto tokenDto = signService.login(userLoginRequestDto);
+        return ResponseFactory.createSingleResult(tokenDto);
     }
 
     @Operation(

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/controller/SignController.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/controller/SignController.java
@@ -1,6 +1,8 @@
 package com.vp.voicepocket.domain.user.controller;
 
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
 import com.vp.voicepocket.domain.token.dto.TokenDto;
 import com.vp.voicepocket.domain.token.dto.TokenRequestDto;
 import com.vp.voicepocket.domain.user.dto.request.UserLoginRequestDto;
@@ -8,7 +10,6 @@ import com.vp.voicepocket.domain.user.dto.request.UserSignupRequestDto;
 import com.vp.voicepocket.domain.user.service.SignService;
 import com.vp.voicepocket.global.common.response.ResponseFactory;
 import com.vp.voicepocket.global.common.response.model.SingleResult;
-import com.vp.voicepocket.global.common.response.service.ResponseService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -18,24 +19,25 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
 @Slf4j
 @Tag(name = "SignUp/LogIn")
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 @RestController
 public class SignController {
+
     private final SignService signService;
-    private final ResponseService responseService;
 
     @Operation(summary = "회원 가입", description = "회원 가입을 합니다.")
     @PostMapping("/signup")
     public SingleResult<Long> signup(
-            @Parameter(description = "회원 가입 요청 DTO", required = true, in = ParameterIn.DEFAULT)
-            @RequestBody @Valid UserSignupRequestDto userSignupRequestDto) {
+        @Parameter(description = "회원 가입 요청 DTO", required = true, in = ParameterIn.DEFAULT)
+        @RequestBody @Valid UserSignupRequestDto userSignupRequestDto) {
         Long signupId = signService.signup(userSignupRequestDto);
         return ResponseFactory.createSingleResult(signupId);
     }
@@ -43,19 +45,20 @@ public class SignController {
     @Operation(summary = "로그인", description = "이메일로 로그인을 합니다.")
     @PostMapping("/login")
     public SingleResult<TokenDto> login(
-            @Parameter(description = "로그인 요청 DTO", required = true)
-            @RequestBody @Valid UserLoginRequestDto userLoginRequestDto) {
+        @Parameter(description = "로그인 요청 DTO", required = true)
+        @RequestBody @Valid UserLoginRequestDto userLoginRequestDto) {
         TokenDto tokenDto = signService.login(userLoginRequestDto);
         return ResponseFactory.createSingleResult(tokenDto);
     }
 
     @Operation(
-            summary = "액세스, 리프레시 토큰 재발급",
-            description = "엑세스 토큰 만료시 회원 검증 후 리프레쉬 토큰을 검증해서 액세스 토큰과 리프레시 토큰을 재발급합니다.")
+        summary = "액세스, 리프레시 토큰 재발급",
+        description = "엑세스 토큰 만료시 회원 검증 후 리프레쉬 토큰을 검증해서 액세스 토큰과 리프레시 토큰을 재발급합니다.")
     @PostMapping("/reissue")
     public SingleResult<TokenDto> reissue(
-            @Parameter(description= "토큰 재발급 요청 DTO", required = true)
-            @RequestBody TokenRequestDto tokenRequestDto) {
-        return responseService.getSingleResult(signService.reissue(tokenRequestDto));
+        @Parameter(description = "Access Token", required = true, hidden = true, in = ParameterIn.HEADER) @RequestHeader(AUTHORIZATION) String accessToken,
+        @Parameter(description = "토큰 재발급 요청 DTO", required = true) @RequestBody @Valid TokenRequestDto tokenRequestDto) {
+        return ResponseFactory.createSingleResult(
+            signService.reissue(accessToken, tokenRequestDto.getRefreshToken()));
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/controller/SignController.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/controller/SignController.java
@@ -11,6 +11,7 @@ import com.vp.voicepocket.global.common.response.model.SingleResult;
 import com.vp.voicepocket.global.common.response.service.ResponseService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,10 +34,10 @@ public class SignController {
     @Operation(summary = "회원 가입", description = "회원 가입을 합니다.")
     @PostMapping("/signup")
     public SingleResult<Long> signup(
-            @Parameter(description = "회원 가입 요청 DTO", required = true)
+            @Parameter(description = "회원 가입 요청 DTO", required = true, in = ParameterIn.DEFAULT)
             @RequestBody @Valid UserSignupRequestDto userSignupRequestDto) {
         Long signupId = signService.signup(userSignupRequestDto);
-        return responseService.getSingleResult(signupId);
+        return ResponseFactory.createSingleResult(signupId);
     }
 
     @Operation(summary = "로그인", description = "이메일로 로그인을 합니다.")

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/controller/UserController.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/controller/UserController.java
@@ -5,13 +5,11 @@ import com.vp.voicepocket.domain.user.dto.request.UserRequestDto;
 import com.vp.voicepocket.domain.user.dto.response.UserResponseDto;
 import com.vp.voicepocket.domain.user.entity.vo.Email;
 import com.vp.voicepocket.domain.user.service.UserService;
+import com.vp.voicepocket.global.common.response.ResponseFactory;
 import com.vp.voicepocket.global.common.response.model.ListResult;
 import com.vp.voicepocket.global.common.response.model.SingleResult;
-import com.vp.voicepocket.global.common.response.service.ResponseService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,59 +26,34 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
-    private final ResponseService responseService;
 
-    @Parameter(
-        name = "X-AUTH-TOKEN",
-        description = "로그인 성공 후 AccessToken",
-        required = true,
-        schema = @Schema(type = "string"),
-        in = ParameterIn.HEADER)
     @Operation(summary = "회원 단건 검색", description = "userId로 회원을 조회합니다.")
     @GetMapping("/user/id/{userId}")
     public SingleResult<UserResponseDto> findUserById(
         @Parameter(description = "회원 ID", required = true) @PathVariable Long userId,
         @Parameter(description = "언어", example = "ko") @RequestParam String lang) {
-        return responseService.getSingleResult(userService.findUserById(userId));
+        return ResponseFactory.createSingleResult(userService.findUserById(userId));
     }
 
-    @Parameter(
-        name = "X-AUTH-TOKEN",
-        description = "로그인 성공 후 AccessToken",
-        required = true,
-        schema = @Schema(type = "string"),
-        in = ParameterIn.HEADER)
     @Operation(summary = "회원 단건 검색 (이메일)", description = "이메일로 회원을 조회합니다.")
     @GetMapping("/user/email/{email}")
     public SingleResult<UserResponseDto> findUserByEmail(
         @Parameter(description = "회원 이메일", required = true) @PathVariable String email,
         @Parameter(description = "언어", example = "ko") @RequestParam String lang) {
-        return responseService.getSingleResult(userService.findUserByEmail(Email.from(email)));
+        return ResponseFactory.createSingleResult(userService.findUserByEmail(Email.from(email)));
     }
 
-    @Parameter(
-        name = "X-AUTH-TOKEN",
-        description = "로그인 성공 후 AccessToken",
-        required = true,
-        schema = @Schema(type = "string"),
-        in = ParameterIn.HEADER)
     @Operation(summary = "회원 목록 조회", description = "모든 회원을 조회합니다.")
     @GetMapping("/users")
     public ListResult<UserResponseDto> findAllUser() {
-        return responseService.getListResult(userService.findAllUser());
+        return ResponseFactory.createListResult(userService.findAllUser());
     }
 
-    @Parameter(
-        name = "X-AUTH-TOKEN",
-        description = "로그인 성공 후 AccessToken",
-        required = true,
-        schema = @Schema(type = "string"),
-        in = ParameterIn.HEADER)
     @PutMapping("/user")
     public SingleResult<Long> update(
         @Parameter(description = "회원 ID", required = true) @RequestParam Long userId,
         @Parameter(description = "회원 이름", required = true) @RequestParam String nickName) {
         UserRequestDto userRequestDto = UserRequestDto.builder().nickName(nickName).build();
-        return responseService.getSingleResult(userService.updateUserData(userId, userRequestDto));
+        return ResponseFactory.createSingleResult(userService.updateUserData(userId, userRequestDto));
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/controller/UserController.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/controller/UserController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "User")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/admin")
 public class UserController {
 
     private final UserService userService;

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/dto/request/UserLoginRequestDto.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/dto/request/UserLoginRequestDto.java
@@ -4,14 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-@Builder
 @Schema(title = "User Login Request", description = "사용자 로그인 입력 모델")
 public class UserLoginRequestDto {
 
@@ -22,4 +18,8 @@ public class UserLoginRequestDto {
     @Schema(title = "password", description = "사용자 패스워드", example = "sample!")
     @NotBlank
     private String password;
+
+    @Schema(title = "fcmToken", description = "FCM Token", example = "sampleToken")
+    @NotBlank
+    private String fcmToken;
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/entity/User.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.vp.voicepocket.domain.user.entity;
 
 import com.vp.voicepocket.domain.user.entity.enums.UserRole;
 import com.vp.voicepocket.domain.user.entity.vo.Email;
+import com.vp.voicepocket.domain.user.exception.CEmailLoginFailedException;
 import com.vp.voicepocket.global.common.BaseEntity;
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 
 @Getter
@@ -69,6 +71,12 @@ public class User extends BaseEntity implements UserDetails {
 
     public void deleteUser() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void verifyPassword(PasswordEncoder passwordEncoder, String password) {
+        if (!passwordEncoder.matches(password, this.password)) {
+            throw new CEmailLoginFailedException();
+        }
     }
 
     @Override

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/entity/enums/UserRole.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/entity/enums/UserRole.java
@@ -1,5 +1,14 @@
 package com.vp.voicepocket.domain.user.entity.enums;
 
 public enum UserRole {
-    ROLE_USER, ROLE_ADMIN
+    ROLE_USER, ROLE_ADMIN;
+
+    public static boolean isUserRole(String role) {
+        for (UserRole userRole : UserRole.values()) {
+            if (userRole.name().equals(role)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/service/SignService.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/service/SignService.java
@@ -16,7 +16,6 @@ import com.vp.voicepocket.domain.user.exception.CEmailLoginFailedException;
 import com.vp.voicepocket.domain.user.exception.CEmailSignUpFailedException;
 import com.vp.voicepocket.domain.user.exception.CUserNotFoundException;
 import com.vp.voicepocket.domain.user.repository.UserRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -56,8 +55,7 @@ public class SignService {
         }
 
         // token 발급
-        TokenDto tokenDto = jwtProvider.createTokenDto(user.getId(),
-            List.of(user.getRole().toString()), user.getEmail());
+        TokenDto tokenDto = jwtProvider.generateTokens(user.getId(), user.getRole().toString());
 
         if (refreshTokenRepository.findByKey(user.getId()).isPresent()) {
             RefreshToken refreshToken = refreshTokenRepository.findByKey(user.getId()).get();
@@ -96,7 +94,7 @@ public class SignService {
                 .orElseThrow(CUserNotFoundException::new);
 
         // AccessToken, RefreshToken 토큰 재발급, 리프레쉬 토큰 저장
-        return jwtProvider.updateAccessTokenDto(user.getId(), List.of(user.getRole().toString()),
+        return jwtProvider.reissueAccessToken(user.getId(), user.getRole().toString(),
             refreshToken);
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/service/SignService.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/service/SignService.java
@@ -35,9 +35,9 @@ public class SignService {
 
     @Transactional
     public Long signup(UserSignupRequestDto userSignupRequestDto) {
-        if (userRepository.findByEmail(userSignupRequestDto.getEmail()).isPresent()) {
+        userRepository.findByEmail(userSignupRequestDto.getEmail()).ifPresent(user -> {
             throw new CEmailSignUpFailedException();
-        }
+        });
         return userRepository.save(userSignupRequestDto.toEntity(passwordEncoder)).getId();
     }
 

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/service/SignService.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/service/SignService.java
@@ -59,7 +59,8 @@ public class SignService {
 
         if (refreshTokenRepository.findByKey(user.getId()).isPresent()) {
             RefreshToken refreshToken = refreshTokenRepository.findByKey(user.getId()).get();
-            refreshToken.updateToken(tokenDto.getRefreshToken());
+            refreshToken.updateToken(tokenDto.getRefreshToken(),
+                tokenDto.getRefreshTokenExpiryDate());
         } else {
             refreshTokenRepository.save(tokenDto.toEntity(user));
         }
@@ -90,11 +91,11 @@ public class SignService {
         // user pk로 유저 검색 / repo 에 저장된 Refresh Token 가져오기
         User user =
             userRepository
-                .findById(refreshTokenEntity.getKey())
+                .findById(refreshTokenEntity.getId())
                 .orElseThrow(CUserNotFoundException::new);
 
         // AccessToken, RefreshToken 토큰 재발급, 리프레쉬 토큰 저장
         return jwtProvider.reissueAccessToken(user.getId(), user.getRole().toString(),
-            refreshToken, 0L);
+            refreshToken, refreshTokenEntity.getExpiryDate());
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/service/SignService.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/service/SignService.java
@@ -95,6 +95,6 @@ public class SignService {
 
         // AccessToken, RefreshToken 토큰 재발급, 리프레쉬 토큰 저장
         return jwtProvider.reissueAccessToken(user.getId(), user.getRole().toString(),
-            refreshToken);
+            refreshToken, 0L);
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/domain/user/service/SignService.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/domain/user/service/SignService.java
@@ -57,8 +57,8 @@ public class SignService {
         // token 발급
         TokenDto tokenDto = jwtProvider.generateTokens(user.getId(), user.getRole().toString());
 
-        if (refreshTokenRepository.findByKey(user.getId()).isPresent()) {
-            RefreshToken refreshToken = refreshTokenRepository.findByKey(user.getId()).get();
+        if (refreshTokenRepository.findById(user.getId()).isPresent()) {
+            RefreshToken refreshToken = refreshTokenRepository.findById(user.getId()).get();
             refreshToken.updateToken(tokenDto.getRefreshToken(),
                 tokenDto.getRefreshTokenExpiryDate());
         } else {
@@ -85,7 +85,7 @@ public class SignService {
 
         // RefreshTokenRepository 에서 Username (pk) 가져오기
         String refreshToken = tokenRequestDto.getRefreshToken();
-        RefreshToken refreshTokenEntity = refreshTokenRepository.findByToken(refreshToken)
+        RefreshToken refreshTokenEntity = refreshTokenRepository.findByValue(refreshToken)
             .orElseThrow(CRefreshTokenException::new);
 
         // user pk로 유저 검색 / repo 에 저장된 Refresh Token 가져오기

--- a/voicepocket/src/main/java/com/vp/voicepocket/global/config/SecurityConfiguration.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/global/config/SecurityConfiguration.java
@@ -6,16 +6,18 @@ import com.vp.voicepocket.domain.token.config.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @RequiredArgsConstructor
 @Configuration
 public class SecurityConfiguration {
+
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
@@ -23,32 +25,40 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-                .httpBasic().disable() // 기본설정은 비 인증시 로그인 폼 화면으로 리다이렉트 되는데 RestApi이므로 disable 함
-                .csrf().disable() // rest api이므로 상태를 저장하지 않으니 csrf 보안을 설정하지 않아도된다.
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // Jwt으로 인증하므로 세션이 필요지 않으므로 생성 안한다.
+            .httpBasic().disable() // 기본설정은 비 인증시 로그인 폼 화면으로 리다이렉트 되는데 RestApi이므로 disable 함
+            .csrf().disable() // rest api이므로 상태를 저장하지 않으니 csrf 보안을 설정하지 않아도된다.
+            .formLogin().disable()
+            .logout().disable()
+            .sessionManagement().sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS) // Jwt으로 인증하므로 세션이 필요지 않으므로 생성 안한다.
 
-                .and()
-                .authorizeRequests() // URL 별 권한 관리를 설정하는 옵션의 시작점, antMathcers를 작성하기 위해서는 먼저 선언되어야 한다.
-                .antMatchers(HttpMethod.POST, "/api/signup", "/api/login", "/api/reissue")
-                .permitAll()
-                .anyRequest() // 그 외 나머지 요청은 인증된 회원만 가능함
-                .hasRole("USER")
+            .and()
+            .authorizeRequests() // URL 별 권한 관리를 설정하는 옵션의 시작점, antMathcers를 작성하기 위해서는 먼저 선언되어야 한다.
+            .antMatchers("/api/v1/auth/**").permitAll()
+            .antMatchers("/api/v1/admin/**").hasRole("ADMIN")
+            .anyRequest().hasRole("USER")
 
-                .and()
-                .exceptionHandling()
-                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
-                .accessDeniedHandler(jwtAccessDeniedHandler)
+            .and()
+            .exceptionHandling()
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            .accessDeniedHandler(jwtAccessDeniedHandler)
 
-                .and()
-                .addFilterBefore(
-                        jwtAuthenticationFilter, BasicAuthenticationFilter.class
-                )
-                .build();
+            .and()
+            .addFilterBefore(
+                jwtAuthenticationFilter, BasicAuthenticationFilter.class
+            )
+            .build();
     }
 
     @Bean
     public WebSecurityCustomizer ignoringWebSecurityCustomizer() {
-        return (web) -> web.ignoring()
-                .antMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**", "/favicon.ico", "/error");
+        return web -> web.ignoring()
+            .antMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**",
+                "/favicon.ico", "/error");
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/global/config/SwaggerConfiguration.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/global/config/SwaggerConfiguration.java
@@ -1,17 +1,36 @@
 package com.vp.voicepocket.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfiguration {
+
     @Bean
     public OpenAPI demoOpenAPI() {
+
+        var info = new Info().title("Voice Pocket project API")
+            .description("Voice Pocket application").version("v0.0.1");
+
+        var jwtScheme = "jwtAuth";
+        var securityRequirement = new SecurityRequirement().addList(jwtScheme);
+        var components = new Components()
+            .addSecuritySchemes(jwtScheme, new SecurityScheme()
+                .name("Authorization")
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .scheme("Bearer")
+                .bearerFormat("JWT"));
+
         return new OpenAPI()
-                .info(new Info().title("Voice Pocket project API")
-                        .description("Voice Pocket application")
-                        .version("v0.0.1"));
+            .components(new Components())
+            .info(info)
+            .addSecurityItem(securityRequirement)
+            .components(components);
     }
 }

--- a/voicepocket/src/main/java/com/vp/voicepocket/global/exception/GlobalExceptionHandler.java
+++ b/voicepocket/src/main/java/com/vp/voicepocket/global/exception/GlobalExceptionHandler.java
@@ -3,13 +3,18 @@ package com.vp.voicepocket.global.exception;
 import com.vp.voicepocket.domain.firebase.exception.CFCMTokenNotFoundException;
 import com.vp.voicepocket.domain.friend.exception.CFriendRequestNotExistException;
 import com.vp.voicepocket.domain.friend.exception.CFriendRequestOnGoingException;
-import com.vp.voicepocket.domain.token.exception.*;
+import com.vp.voicepocket.domain.token.exception.CAccessDeniedException;
+import com.vp.voicepocket.domain.token.exception.CAccessTokenException;
+import com.vp.voicepocket.domain.token.exception.CAuthenticationEntryPointException;
+import com.vp.voicepocket.domain.token.exception.CExpiredAccessTokenException;
+import com.vp.voicepocket.domain.token.exception.CRefreshTokenException;
 import com.vp.voicepocket.domain.user.exception.CEmailLoginFailedException;
 import com.vp.voicepocket.domain.user.exception.CEmailSignUpFailedException;
 import com.vp.voicepocket.domain.user.exception.CUserNotFoundException;
+import com.vp.voicepocket.global.common.response.ResponseFactory;
 import com.vp.voicepocket.global.common.response.model.CommonResult;
-import com.vp.voicepocket.global.common.response.service.ResponseService;
 import io.jsonwebtoken.MalformedJwtException;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
@@ -18,12 +23,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import javax.servlet.http.HttpServletRequest;
-
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
-    private final ResponseService responseService;
     private final MessageSource messageSource;
 
     private String getMessage(String code) {
@@ -40,9 +42,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected CommonResult defaultException(HttpServletRequest request, Exception e) {
-        return responseService.getFailResult
+        return ResponseFactory.createFailResult(
         //        (Integer.parseInt(getMessage("unKnown.code")), getMessage("unKnown.msg"));
-                (Integer.parseInt(getMessage("unKnown.code")), e.getMessage());
+                (Integer.parseInt(getMessage("unKnown.code"))), e.getMessage());
     }
 
     /***
@@ -53,7 +55,7 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     protected CommonResult userNotFoundException(
             HttpServletRequest request, CUserNotFoundException e) {
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("userNotFound.code")), getMessage("userNotFound.msg"));
     }
 
@@ -64,7 +66,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CEmailLoginFailedException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     protected CommonResult emailLoginFailedException(HttpServletRequest request, CEmailLoginFailedException e) {
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("emailLoginFailed.code")), getMessage("emailLoginFailed.msg")
         );
     }
@@ -76,7 +78,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CEmailSignUpFailedException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     protected CommonResult emailSignupFailedException(HttpServletRequest request, CEmailSignUpFailedException e) {
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("emailSignupFailed.code")), getMessage("emailSignupFailed.msg")
         );
     }
@@ -86,7 +88,7 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     protected CommonResult authenticationEntrypointException(
             HttpServletRequest request, CAuthenticationEntryPointException e) {
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("authenticationEntrypoint.code")),
                 getMessage("authenticationEntrypoint.msg"));
     }
@@ -98,7 +100,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CAccessDeniedException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     protected CommonResult accessDeniedException(HttpServletRequest request, CAccessDeniedException e) {
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("accessDenied.code")), getMessage("accessDenied.msg")
         );
     }
@@ -110,7 +112,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CRefreshTokenException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     protected CommonResult refreshTokenException(HttpServletRequest request, CRefreshTokenException e) {
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("refreshTokenInValid.code")), getMessage("refreshTokenInValid.msg")
         );
     }
@@ -122,7 +124,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CExpiredAccessTokenException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     protected CommonResult expiredAccessTokenException(HttpServletRequest request, CExpiredAccessTokenException e) {
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("expiredAccessToken.code")), getMessage("expiredAccessToken.msg")
         );
     }
@@ -134,7 +136,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CAccessTokenException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     protected CommonResult accessTokenException(HttpServletRequest request, CAccessTokenException e) {
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("accessTokenInValid.code")), getMessage("accessTokenInValid.msg")
         );
     }
@@ -142,7 +144,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MalformedJwtException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     protected CommonResult malformedJwtException(HttpServletRequest request, MalformedJwtException e){
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("malformedToken.code")), getMessage("malformedToken.msg")
         );
     }
@@ -154,7 +156,7 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     protected CommonResult friendRequestNotExistException(
             HttpServletRequest request, CFriendRequestNotExistException e) {
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("friendRequestNotExist.code")), getMessage("friendRequestNotExist.msg"));
     }
 
@@ -166,7 +168,7 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     protected CommonResult friendRequestOnGoingException(
             HttpServletRequest request, CFriendRequestOnGoingException e){
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("friendRequestOnGoing.code")), getMessage("friendRequestOnGoing.msg"));
     }
 
@@ -178,7 +180,7 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     protected CommonResult userNotFoundException(
             HttpServletRequest request, CFCMTokenNotFoundException e) {
-        return responseService.getFailResult(
+        return ResponseFactory.createFailResult(
                 Integer.parseInt(getMessage("FCMTokenNotFound.code")), getMessage("FCMTokenNotFound.msg"));
     }
 }


### PR DESCRIPTION
## 리펙토링 내역
- 토큰 인증 방식을 [RFC-6750](https://datatracker.ietf.org/doc/html/rfc6750)에 맞추었습니다.
  - 이제 인증시 헤더에 `Authorization: Bearer ~` 형식으로 Access Token을 전달해야합니다.
- 토큰 생성 방식에 대한 리팩토링을 진행했습니다.
  - 불필요하게 중복된 코드를 삭제했습니다.
- `TokenDTO` 리팩토링을 진행했습니다.
  - 이제 `TokenDTO`는 AccessTokenExpiryDate 대신 RefreshTokenExpiryDate를 갖습니다.
- 토큰 검증 방식에 대한 리팩토링을 진행했습니다.
- 토큰 재발급 `reissue` 로직이 변경되었습니다.
  - 이제 토큰 재발급을 위해서는 헤더에 `Authorization: Bearer ~` 형식으로 Access Token을 body에 Refresh Token을 전달해주어야 합니다.
- 토큰 재발급 로직 변경에 따라 `RefreshToken` Entity 필드가 수정되었습니다.
  - id를 자동생성하지 않고 user 엔티티의 id를 전달받아 생성됩니다.
  - `token` 필드가 `value`필드로 이름이 변경되었습니다.
  - `refreshTokenExpiryDate` 필드가 추가되었습니다. -> `reissue` 과정에서 이를 활용하여 검증을 진행합니다.
- 기존 Access Token으로 불필요한 인가를 두번 진행하던 로직을 전부 삭제하고 (`Friend`, `Message` 도메인) `@AuthenticationPrincipal`에 의해 인가도 이루어지도록 코드를 리팩토링했습니다.
- "X-AUTH-TOKEN" 헤더 값을 명시한 `Controller`의 모든 값들을 삭제했습니다.
- `Deprecated`된 `ResponseService`를 전부 변경했으며 이에 따라 `ResponseService`를 삭제했습니다.

## 연관 Issue
- close #48 